### PR TITLE
fix build with older ESPHome

### DIFF
--- a/wmbus_utils.cpp
+++ b/wmbus_utils.cpp
@@ -6,7 +6,9 @@
 #include"wmbus_utils.hpp"
 
 #include<assert.h>
+/**************
 #include<memory.h>
+**************/
 #include<vector>
 
 namespace std


### PR DESCRIPTION
Reproduction for fix: docker run --rm -v "${PWD}":/config  -it esphome/esphome:2022.11.5 run water-meter.yaml
Fix: comment unwanted/missing lib.

